### PR TITLE
styling: fix links

### DIFF
--- a/exercises/01.styling/03.problem.route-links/README.mdx
+++ b/exercises/01.styling/03.problem.route-links/README.mdx
@@ -22,4 +22,4 @@ route. And those links will be on the page when that route is on the page.
 Moreover, it'll even be removed when that route is not active as well.
 
 📜
-[Remix Route Styles Documentation](https://remix.run/docs/en/1.14.3/guides/styling#md-route-styles)
+[Remix Route Styles Documentation](https://remix.run/docs/en/1.14.3/guides/styling#route-styles)

--- a/exercises/01.styling/04.problem.tailwind/README.mdx
+++ b/exercises/01.styling/04.problem.tailwind/README.mdx
@@ -12,5 +12,5 @@ file! Pretty sure for this one, it'll be obvious when you are successful 😅 Bu
 if you're unsure, pop open the network tab and look for the tailwind.css file
 with the fingerprint hash in the filename.
 
-- 📜 [Remix PostCSS Docs](https://remix.run/docs/en/1.14.3/guides/styling#md-postcss)
-- 📜 [Remix TailwindCSS Docs](https://remix.run/docs/en/1.14.3/guides/styling#md-tailwind-css)
+- 📜 [Remix PostCSS Docs](https://remix.run/docs/en/1.14.3/guides/styling#postcss)
+- 📜 [Remix TailwindCSS Docs](https://remix.run/docs/en/1.14.3/guides/styling#tailwind-css)

--- a/exercises/01.styling/05.problem.css-bundle/README.mdx
+++ b/exercises/01.styling/05.problem.css-bundle/README.mdx
@@ -12,7 +12,7 @@ Because we don't want to load this CSS file on every page, and we also don't
 want to have to list every component-level CSS file in our root route, we're
 going to use yet another built-in feature of Remix that allows us to tell Remix
 where to put global styles we import. In Remix, this is called 📜
-["CSS Bundling"](https://remix.run/docs/en/1.14.3/guides/styling#md-css-bundling).
+["CSS Bundling"](https://remix.run/docs/en/1.14.3/guides/styling#css-bundling).
 
 We already have `@remix-run/css-bundle` installed, so all that's left is to
 `import` it, and list it in the links of our <InlineFile file="app/root.tsx" />.


### PR DESCRIPTION
Fix links: `md-` in links causing not open at mentioned section on styling page of remix docs 