### PR TITLE
fix: VScode JS/TS language service crashed

### DIFF
--- a/exercises/01.styling/01.problem.public-links/.gitignore
+++ b/exercises/01.styling/01.problem.public-links/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/01.styling/01.problem.public-links/tsconfig.json
+++ b/exercises/01.styling/01.problem.public-links/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/01.styling/01.problem.public-links/tsconfig.json
+++ b/exercises/01.styling/01.problem.public-links/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/01.styling/01.solution.public-links/.gitignore
+++ b/exercises/01.styling/01.solution.public-links/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/01.styling/01.solution.public-links/tsconfig.json
+++ b/exercises/01.styling/01.solution.public-links/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/01.styling/01.solution.public-links/tsconfig.json
+++ b/exercises/01.styling/01.solution.public-links/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/01.styling/02.problem.global-links/.gitignore
+++ b/exercises/01.styling/02.problem.global-links/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/01.styling/02.problem.global-links/tsconfig.json
+++ b/exercises/01.styling/02.problem.global-links/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/01.styling/02.problem.global-links/tsconfig.json
+++ b/exercises/01.styling/02.problem.global-links/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/01.styling/02.solution.global-links/.gitignore
+++ b/exercises/01.styling/02.solution.global-links/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/01.styling/02.solution.global-links/tsconfig.json
+++ b/exercises/01.styling/02.solution.global-links/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/01.styling/02.solution.global-links/tsconfig.json
+++ b/exercises/01.styling/02.solution.global-links/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/01.styling/03.problem.route-links/.gitignore
+++ b/exercises/01.styling/03.problem.route-links/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/01.styling/03.problem.route-links/tsconfig.json
+++ b/exercises/01.styling/03.problem.route-links/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/01.styling/03.problem.route-links/tsconfig.json
+++ b/exercises/01.styling/03.problem.route-links/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/01.styling/03.solution.route-links/.gitignore
+++ b/exercises/01.styling/03.solution.route-links/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/01.styling/03.solution.route-links/tsconfig.json
+++ b/exercises/01.styling/03.solution.route-links/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/01.styling/03.solution.route-links/tsconfig.json
+++ b/exercises/01.styling/03.solution.route-links/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/01.styling/04.problem.tailwind/.gitignore
+++ b/exercises/01.styling/04.problem.tailwind/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/01.styling/04.problem.tailwind/tsconfig.json
+++ b/exercises/01.styling/04.problem.tailwind/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/01.styling/04.problem.tailwind/tsconfig.json
+++ b/exercises/01.styling/04.problem.tailwind/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/01.styling/04.solution.tailwind/.gitignore
+++ b/exercises/01.styling/04.solution.tailwind/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/01.styling/04.solution.tailwind/tsconfig.json
+++ b/exercises/01.styling/04.solution.tailwind/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/01.styling/04.solution.tailwind/tsconfig.json
+++ b/exercises/01.styling/04.solution.tailwind/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/01.styling/05.problem.css-bundle/.gitignore
+++ b/exercises/01.styling/05.problem.css-bundle/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/01.styling/05.problem.css-bundle/tsconfig.json
+++ b/exercises/01.styling/05.problem.css-bundle/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/01.styling/05.problem.css-bundle/tsconfig.json
+++ b/exercises/01.styling/05.problem.css-bundle/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/01.styling/05.solution.css-bundle/.gitignore
+++ b/exercises/01.styling/05.solution.css-bundle/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/01.styling/05.solution.css-bundle/tsconfig.json
+++ b/exercises/01.styling/05.solution.css-bundle/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/01.styling/05.solution.css-bundle/tsconfig.json
+++ b/exercises/01.styling/05.solution.css-bundle/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/02.routing/01.problem.routes/.gitignore
+++ b/exercises/02.routing/01.problem.routes/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/02.routing/01.problem.routes/tsconfig.json
+++ b/exercises/02.routing/01.problem.routes/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/02.routing/01.problem.routes/tsconfig.json
+++ b/exercises/02.routing/01.problem.routes/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/02.routing/01.solution.routes/.gitignore
+++ b/exercises/02.routing/01.solution.routes/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/02.routing/01.solution.routes/tsconfig.json
+++ b/exercises/02.routing/01.solution.routes/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/02.routing/01.solution.routes/tsconfig.json
+++ b/exercises/02.routing/01.solution.routes/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/02.routing/02.problem.links/.gitignore
+++ b/exercises/02.routing/02.problem.links/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/02.routing/02.problem.links/tsconfig.json
+++ b/exercises/02.routing/02.problem.links/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/02.routing/02.problem.links/tsconfig.json
+++ b/exercises/02.routing/02.problem.links/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/02.routing/02.solution.links/.gitignore
+++ b/exercises/02.routing/02.solution.links/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/02.routing/02.solution.links/tsconfig.json
+++ b/exercises/02.routing/02.solution.links/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/02.routing/02.solution.links/tsconfig.json
+++ b/exercises/02.routing/02.solution.links/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/02.routing/03.problem.params/.gitignore
+++ b/exercises/02.routing/03.problem.params/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/02.routing/03.problem.params/tsconfig.json
+++ b/exercises/02.routing/03.problem.params/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/02.routing/03.problem.params/tsconfig.json
+++ b/exercises/02.routing/03.problem.params/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/02.routing/03.solution.params/.gitignore
+++ b/exercises/02.routing/03.solution.params/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/02.routing/03.solution.params/tsconfig.json
+++ b/exercises/02.routing/03.solution.params/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/02.routing/03.solution.params/tsconfig.json
+++ b/exercises/02.routing/03.solution.params/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/03.loading/01.problem.loaders/.gitignore
+++ b/exercises/03.loading/01.problem.loaders/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/03.loading/01.problem.loaders/tsconfig.json
+++ b/exercises/03.loading/01.problem.loaders/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/03.loading/01.problem.loaders/tsconfig.json
+++ b/exercises/03.loading/01.problem.loaders/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/03.loading/01.solution.loaders/.gitignore
+++ b/exercises/03.loading/01.solution.loaders/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/03.loading/01.solution.loaders/tsconfig.json
+++ b/exercises/03.loading/01.solution.loaders/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/03.loading/01.solution.loaders/tsconfig.json
+++ b/exercises/03.loading/01.solution.loaders/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/03.loading/02.problem.missing-data/.gitignore
+++ b/exercises/03.loading/02.problem.missing-data/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/03.loading/02.problem.missing-data/tsconfig.json
+++ b/exercises/03.loading/02.problem.missing-data/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/03.loading/02.problem.missing-data/tsconfig.json
+++ b/exercises/03.loading/02.problem.missing-data/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/03.loading/02.solution.missing-data/.gitignore
+++ b/exercises/03.loading/02.solution.missing-data/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/03.loading/02.solution.missing-data/tsconfig.json
+++ b/exercises/03.loading/02.solution.missing-data/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/03.loading/02.solution.missing-data/tsconfig.json
+++ b/exercises/03.loading/02.solution.missing-data/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/04.mutations/01.problem.forms/.gitignore
+++ b/exercises/04.mutations/01.problem.forms/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/04.mutations/01.problem.forms/tsconfig.json
+++ b/exercises/04.mutations/01.problem.forms/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/04.mutations/01.problem.forms/tsconfig.json
+++ b/exercises/04.mutations/01.problem.forms/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/04.mutations/01.solution.forms/.gitignore
+++ b/exercises/04.mutations/01.solution.forms/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/04.mutations/01.solution.forms/tsconfig.json
+++ b/exercises/04.mutations/01.solution.forms/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/04.mutations/01.solution.forms/tsconfig.json
+++ b/exercises/04.mutations/01.solution.forms/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/04.mutations/02.problem.actions/.gitignore
+++ b/exercises/04.mutations/02.problem.actions/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/04.mutations/02.problem.actions/tsconfig.json
+++ b/exercises/04.mutations/02.problem.actions/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/04.mutations/02.problem.actions/tsconfig.json
+++ b/exercises/04.mutations/02.problem.actions/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/04.mutations/02.solution.actions/.gitignore
+++ b/exercises/04.mutations/02.solution.actions/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/04.mutations/02.solution.actions/tsconfig.json
+++ b/exercises/04.mutations/02.solution.actions/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/04.mutations/02.solution.actions/tsconfig.json
+++ b/exercises/04.mutations/02.solution.actions/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/04.mutations/03.problem.fields/.gitignore
+++ b/exercises/04.mutations/03.problem.fields/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/04.mutations/03.problem.fields/tsconfig.json
+++ b/exercises/04.mutations/03.problem.fields/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/04.mutations/03.problem.fields/tsconfig.json
+++ b/exercises/04.mutations/03.problem.fields/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/04.mutations/03.solution.fields/.gitignore
+++ b/exercises/04.mutations/03.solution.fields/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/04.mutations/03.solution.fields/tsconfig.json
+++ b/exercises/04.mutations/03.solution.fields/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/04.mutations/03.solution.fields/tsconfig.json
+++ b/exercises/04.mutations/03.solution.fields/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/04.mutations/04.problem.typescript/.gitignore
+++ b/exercises/04.mutations/04.problem.typescript/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/04.mutations/04.problem.typescript/tsconfig.json
+++ b/exercises/04.mutations/04.problem.typescript/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/04.mutations/04.problem.typescript/tsconfig.json
+++ b/exercises/04.mutations/04.problem.typescript/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/04.mutations/04.solution.typescript/.gitignore
+++ b/exercises/04.mutations/04.solution.typescript/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/04.mutations/04.solution.typescript/tsconfig.json
+++ b/exercises/04.mutations/04.solution.typescript/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/04.mutations/04.solution.typescript/tsconfig.json
+++ b/exercises/04.mutations/04.solution.typescript/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/05.scripting/01.problem.scripts/.gitignore
+++ b/exercises/05.scripting/01.problem.scripts/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/05.scripting/01.problem.scripts/tsconfig.json
+++ b/exercises/05.scripting/01.problem.scripts/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/05.scripting/01.problem.scripts/tsconfig.json
+++ b/exercises/05.scripting/01.problem.scripts/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/05.scripting/01.solution.scripts/.gitignore
+++ b/exercises/05.scripting/01.solution.scripts/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/05.scripting/01.solution.scripts/tsconfig.json
+++ b/exercises/05.scripting/01.solution.scripts/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/05.scripting/01.solution.scripts/tsconfig.json
+++ b/exercises/05.scripting/01.solution.scripts/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/05.scripting/02.problem.scroll-restoration/.gitignore
+++ b/exercises/05.scripting/02.problem.scroll-restoration/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/05.scripting/02.problem.scroll-restoration/tsconfig.json
+++ b/exercises/05.scripting/02.problem.scroll-restoration/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/05.scripting/02.problem.scroll-restoration/tsconfig.json
+++ b/exercises/05.scripting/02.problem.scroll-restoration/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/05.scripting/02.solution.scroll-restoration/.gitignore
+++ b/exercises/05.scripting/02.solution.scroll-restoration/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/05.scripting/02.solution.scroll-restoration/tsconfig.json
+++ b/exercises/05.scripting/02.solution.scroll-restoration/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/05.scripting/02.solution.scroll-restoration/tsconfig.json
+++ b/exercises/05.scripting/02.solution.scroll-restoration/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/05.scripting/03.problem.custom-scripts/.gitignore
+++ b/exercises/05.scripting/03.problem.custom-scripts/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/05.scripting/03.problem.custom-scripts/tsconfig.json
+++ b/exercises/05.scripting/03.problem.custom-scripts/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/05.scripting/03.problem.custom-scripts/tsconfig.json
+++ b/exercises/05.scripting/03.problem.custom-scripts/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/05.scripting/03.solution.custom-scripts/.gitignore
+++ b/exercises/05.scripting/03.solution.custom-scripts/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/05.scripting/03.solution.custom-scripts/tsconfig.json
+++ b/exercises/05.scripting/03.solution.custom-scripts/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/05.scripting/03.solution.custom-scripts/tsconfig.json
+++ b/exercises/05.scripting/03.solution.custom-scripts/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/05.scripting/04.problem.prefetching/.gitignore
+++ b/exercises/05.scripting/04.problem.prefetching/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/05.scripting/04.problem.prefetching/tsconfig.json
+++ b/exercises/05.scripting/04.problem.prefetching/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/05.scripting/04.problem.prefetching/tsconfig.json
+++ b/exercises/05.scripting/04.problem.prefetching/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/05.scripting/04.solution.prefetching/.gitignore
+++ b/exercises/05.scripting/04.solution.prefetching/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/05.scripting/04.solution.prefetching/tsconfig.json
+++ b/exercises/05.scripting/04.solution.prefetching/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/05.scripting/04.solution.prefetching/tsconfig.json
+++ b/exercises/05.scripting/04.solution.prefetching/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/05.scripting/05.problem.pending/.gitignore
+++ b/exercises/05.scripting/05.problem.pending/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/05.scripting/05.problem.pending/tsconfig.json
+++ b/exercises/05.scripting/05.problem.pending/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/05.scripting/05.problem.pending/tsconfig.json
+++ b/exercises/05.scripting/05.problem.pending/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/05.scripting/05.solution.pending/.gitignore
+++ b/exercises/05.scripting/05.solution.pending/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/05.scripting/05.solution.pending/tsconfig.json
+++ b/exercises/05.scripting/05.solution.pending/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/05.scripting/05.solution.pending/tsconfig.json
+++ b/exercises/05.scripting/05.solution.pending/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/06.seo/01.problem.static/.gitignore
+++ b/exercises/06.seo/01.problem.static/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/06.seo/01.problem.static/tsconfig.json
+++ b/exercises/06.seo/01.problem.static/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/06.seo/01.problem.static/tsconfig.json
+++ b/exercises/06.seo/01.problem.static/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/06.seo/01.solution.static/.gitignore
+++ b/exercises/06.seo/01.solution.static/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/06.seo/01.solution.static/tsconfig.json
+++ b/exercises/06.seo/01.solution.static/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/06.seo/01.solution.static/tsconfig.json
+++ b/exercises/06.seo/01.solution.static/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/06.seo/02.problem.nested/.gitignore
+++ b/exercises/06.seo/02.problem.nested/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/06.seo/02.problem.nested/tsconfig.json
+++ b/exercises/06.seo/02.problem.nested/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/06.seo/02.problem.nested/tsconfig.json
+++ b/exercises/06.seo/02.problem.nested/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/06.seo/02.solution.nested/.gitignore
+++ b/exercises/06.seo/02.solution.nested/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/06.seo/02.solution.nested/tsconfig.json
+++ b/exercises/06.seo/02.solution.nested/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/06.seo/02.solution.nested/tsconfig.json
+++ b/exercises/06.seo/02.solution.nested/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/06.seo/03.problem.dynamic/.gitignore
+++ b/exercises/06.seo/03.problem.dynamic/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/06.seo/03.problem.dynamic/tsconfig.json
+++ b/exercises/06.seo/03.problem.dynamic/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/06.seo/03.problem.dynamic/tsconfig.json
+++ b/exercises/06.seo/03.problem.dynamic/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/06.seo/03.solution.dynamic/.gitignore
+++ b/exercises/06.seo/03.solution.dynamic/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/06.seo/03.solution.dynamic/tsconfig.json
+++ b/exercises/06.seo/03.solution.dynamic/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/06.seo/03.solution.dynamic/tsconfig.json
+++ b/exercises/06.seo/03.solution.dynamic/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/06.seo/04.problem.errors/.gitignore
+++ b/exercises/06.seo/04.problem.errors/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/06.seo/04.problem.errors/tsconfig.json
+++ b/exercises/06.seo/04.problem.errors/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/06.seo/04.problem.errors/tsconfig.json
+++ b/exercises/06.seo/04.problem.errors/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/06.seo/04.solution.errors/.gitignore
+++ b/exercises/06.seo/04.solution.errors/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/06.seo/04.solution.errors/tsconfig.json
+++ b/exercises/06.seo/04.solution.errors/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/06.seo/04.solution.errors/tsconfig.json
+++ b/exercises/06.seo/04.solution.errors/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/07.error-handling/01.problem.route-errors/.gitignore
+++ b/exercises/07.error-handling/01.problem.route-errors/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/07.error-handling/01.problem.route-errors/tsconfig.json
+++ b/exercises/07.error-handling/01.problem.route-errors/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/07.error-handling/01.problem.route-errors/tsconfig.json
+++ b/exercises/07.error-handling/01.problem.route-errors/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/07.error-handling/01.solution.route-errors/.gitignore
+++ b/exercises/07.error-handling/01.solution.route-errors/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/07.error-handling/01.solution.route-errors/tsconfig.json
+++ b/exercises/07.error-handling/01.solution.route-errors/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/07.error-handling/01.solution.route-errors/tsconfig.json
+++ b/exercises/07.error-handling/01.solution.route-errors/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/07.error-handling/02.problem.error-responses/.gitignore
+++ b/exercises/07.error-handling/02.problem.error-responses/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/07.error-handling/02.problem.error-responses/tsconfig.json
+++ b/exercises/07.error-handling/02.problem.error-responses/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/07.error-handling/02.problem.error-responses/tsconfig.json
+++ b/exercises/07.error-handling/02.problem.error-responses/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/07.error-handling/02.solution.error-responses/.gitignore
+++ b/exercises/07.error-handling/02.solution.error-responses/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/07.error-handling/02.solution.error-responses/tsconfig.json
+++ b/exercises/07.error-handling/02.solution.error-responses/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/07.error-handling/02.solution.error-responses/tsconfig.json
+++ b/exercises/07.error-handling/02.solution.error-responses/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/07.error-handling/03.problem.error-abstraction/.gitignore
+++ b/exercises/07.error-handling/03.problem.error-abstraction/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/07.error-handling/03.problem.error-abstraction/tsconfig.json
+++ b/exercises/07.error-handling/03.problem.error-abstraction/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/07.error-handling/03.problem.error-abstraction/tsconfig.json
+++ b/exercises/07.error-handling/03.problem.error-abstraction/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/07.error-handling/03.solution.error-abstraction/.gitignore
+++ b/exercises/07.error-handling/03.solution.error-abstraction/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/07.error-handling/03.solution.error-abstraction/tsconfig.json
+++ b/exercises/07.error-handling/03.solution.error-abstraction/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/07.error-handling/03.solution.error-abstraction/tsconfig.json
+++ b/exercises/07.error-handling/03.solution.error-abstraction/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/08.form-validation/01.problem.form-validation/.gitignore
+++ b/exercises/08.form-validation/01.problem.form-validation/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/08.form-validation/01.problem.form-validation/tsconfig.json
+++ b/exercises/08.form-validation/01.problem.form-validation/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/08.form-validation/01.problem.form-validation/tsconfig.json
+++ b/exercises/08.form-validation/01.problem.form-validation/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/08.form-validation/01.solution.form-validation/.gitignore
+++ b/exercises/08.form-validation/01.solution.form-validation/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/08.form-validation/01.solution.form-validation/tsconfig.json
+++ b/exercises/08.form-validation/01.solution.form-validation/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/08.form-validation/01.solution.form-validation/tsconfig.json
+++ b/exercises/08.form-validation/01.solution.form-validation/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/08.form-validation/02.problem.no-validate/.gitignore
+++ b/exercises/08.form-validation/02.problem.no-validate/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/08.form-validation/02.problem.no-validate/tsconfig.json
+++ b/exercises/08.form-validation/02.problem.no-validate/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/08.form-validation/02.problem.no-validate/tsconfig.json
+++ b/exercises/08.form-validation/02.problem.no-validate/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/08.form-validation/02.solution.no-validate/.gitignore
+++ b/exercises/08.form-validation/02.solution.no-validate/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/08.form-validation/02.solution.no-validate/tsconfig.json
+++ b/exercises/08.form-validation/02.solution.no-validate/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/08.form-validation/02.solution.no-validate/tsconfig.json
+++ b/exercises/08.form-validation/02.solution.no-validate/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/08.form-validation/03.problem.async-form-validation/.gitignore
+++ b/exercises/08.form-validation/03.problem.async-form-validation/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/08.form-validation/03.problem.async-form-validation/tsconfig.json
+++ b/exercises/08.form-validation/03.problem.async-form-validation/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/08.form-validation/03.problem.async-form-validation/tsconfig.json
+++ b/exercises/08.form-validation/03.problem.async-form-validation/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/08.form-validation/03.solution.async-form-validation/.gitignore
+++ b/exercises/08.form-validation/03.solution.async-form-validation/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/08.form-validation/03.solution.async-form-validation/tsconfig.json
+++ b/exercises/08.form-validation/03.solution.async-form-validation/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/08.form-validation/03.solution.async-form-validation/tsconfig.json
+++ b/exercises/08.form-validation/03.solution.async-form-validation/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/09.accessibility/01.problem.labels/.gitignore
+++ b/exercises/09.accessibility/01.problem.labels/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/09.accessibility/01.problem.labels/tsconfig.json
+++ b/exercises/09.accessibility/01.problem.labels/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/09.accessibility/01.problem.labels/tsconfig.json
+++ b/exercises/09.accessibility/01.problem.labels/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/09.accessibility/01.solution.labels/.gitignore
+++ b/exercises/09.accessibility/01.solution.labels/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/09.accessibility/01.solution.labels/tsconfig.json
+++ b/exercises/09.accessibility/01.solution.labels/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/09.accessibility/01.solution.labels/tsconfig.json
+++ b/exercises/09.accessibility/01.solution.labels/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/09.accessibility/02.problem.aria/.gitignore
+++ b/exercises/09.accessibility/02.problem.aria/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/09.accessibility/02.problem.aria/tsconfig.json
+++ b/exercises/09.accessibility/02.problem.aria/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/09.accessibility/02.problem.aria/tsconfig.json
+++ b/exercises/09.accessibility/02.problem.aria/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/09.accessibility/02.solution.aria/.gitignore
+++ b/exercises/09.accessibility/02.solution.aria/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/09.accessibility/02.solution.aria/tsconfig.json
+++ b/exercises/09.accessibility/02.solution.aria/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/09.accessibility/02.solution.aria/tsconfig.json
+++ b/exercises/09.accessibility/02.solution.aria/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/09.accessibility/03.problem.focus/.gitignore
+++ b/exercises/09.accessibility/03.problem.focus/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/09.accessibility/03.problem.focus/tsconfig.json
+++ b/exercises/09.accessibility/03.problem.focus/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/09.accessibility/03.problem.focus/tsconfig.json
+++ b/exercises/09.accessibility/03.problem.focus/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/09.accessibility/03.solution.focus/.gitignore
+++ b/exercises/09.accessibility/03.solution.focus/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/09.accessibility/03.solution.focus/tsconfig.json
+++ b/exercises/09.accessibility/03.solution.focus/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/09.accessibility/03.solution.focus/tsconfig.json
+++ b/exercises/09.accessibility/03.solution.focus/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/09.accessibility/04.problem.use-focus-invalid/.gitignore
+++ b/exercises/09.accessibility/04.problem.use-focus-invalid/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/09.accessibility/04.problem.use-focus-invalid/tsconfig.json
+++ b/exercises/09.accessibility/04.problem.use-focus-invalid/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/09.accessibility/04.problem.use-focus-invalid/tsconfig.json
+++ b/exercises/09.accessibility/04.problem.use-focus-invalid/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/exercises/09.accessibility/04.solution.use-focus-invalid/.gitignore
+++ b/exercises/09.accessibility/04.solution.use-focus-invalid/.gitignore
@@ -21,3 +21,4 @@ prisma/test
 other/image.db
 
 server-build
+*.tsbuildinfo

--- a/exercises/09.accessibility/04.solution.use-focus-invalid/tsconfig.json
+++ b/exercises/09.accessibility/04.solution.use-focus-invalid/tsconfig.json
@@ -26,6 +26,9 @@
 		},
 		"skipLibCheck": true,
 
+		// Referenced project must have setting "composite": true.
+		"composite": true,
+
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true
 	}

--- a/exercises/09.accessibility/04.solution.use-focus-invalid/tsconfig.json
+++ b/exercises/09.accessibility/04.solution.use-focus-invalid/tsconfig.json
@@ -28,6 +28,9 @@
 
 		// Referenced project must have setting "composite": true.
 		"composite": true,
+		"disableReferencedProjectLoad": true,
+		"disableSolutionSearching": true,
+		"disableSourceOfProjectReferenceRedirect": true,
 
 		// Remix takes care of building everything in `remix build`.
 		"noEmit": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,6 @@
   "exclude": [
     "node_modules"
   ],
-  "compilerOptions": {
-    "disableReferencedProjectLoad": true,
-    "disableSolutionSearching": true,
-    "disableSourceOfProjectReferenceRedirect": true
-  },
   "references": [
     {
       "path": "exercises/01.styling/01.problem.public-links"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,11 @@
   "exclude": [
     "node_modules"
   ],
+  "compilerOptions": {
+    "disableReferencedProjectLoad": true,
+    "disableSolutionSearching": true,
+    "disableSourceOfProjectReferenceRedirect": true
+  },
   "references": [
     {
       "path": "exercises/01.styling/01.problem.public-links"


### PR DESCRIPTION
@kentcdodds

when we open a `.mjs`, `.cjs` or `.js` file at the root of the workshop `VScode JS/TS language service crashed`
we have the same issue on all workshops

I think that the cause of this issue is that we have at the root of the repository `tsconfig` with references to all the exercises in the workshop.

according to [typescript docs](https://www.typescriptlang.org/docs/handbook/project-references.html)  `Referenced projects must have the new composite setting enabled` ([composite](https://www.typescriptlang.org/tsconfig#composite))

so i've added this `"composite": true,` to all `tsconfig.json` files.

now typescript generate [tsBuildInfoFile](https://www.typescriptlang.org/tsconfig#tsBuildInfoFile) on first `tsc -b`
each subsequently `tsc -b` will be faster. (I've added `*.tsbuildinfo` to .gitignore )

that alone will not stop `JS/TS language service` from crashing.
it look to me that since `TypeScript will load all of the available projects into memory` it go out of memory

so after reading [typescript docs](https://www.typescriptlang.org/tsconfig#Projects_6255) again i've added this to the root `tsconfig`.

we don't need any references from one exercises to another.

```diff
{
  "files": [],
  "exclude": [
    "node_modules"
  ],
+ "compilerOptions": {
+   "disableReferencedProjectLoad": true,
+   "disableSolutionSearching": true,
+   "disableSourceOfProjectReferenceRedirect": true
+ },
  "references": [
    {
      "path": "exercises/01.styling/01.problem.public-links"
    },

```